### PR TITLE
Add X account schema

### DIFF
--- a/schemas/x-account.json
+++ b/schemas/x-account.json
@@ -1,0 +1,28 @@
+{
+    "issuer": "X",
+    "desc": "One of the world's largest social media websites and source of news",
+    "website": "https://x.com",
+    "APIs": [
+        {
+            "host": "api.x.com",
+            "intercept": {
+                "url": "1.1/account/settings.json",
+                "method": "GET"
+            },
+            "assert": [
+                {
+                    "key": "screen_name",
+                    "value": " ",
+                    "operation": "!="
+                }
+            ],
+            "nullifier": "screen_name"
+        }
+    ],
+    "HRCondition": [
+        "X Account Owner"
+    ],
+    "tips": {
+        "message": "When you successfully log in, please click the 'Start' button to initiate the verification process."
+    }
+}


### PR DESCRIPTION
This pull request adds an example schema for checking that a user owns an X account. The schema asserts that the screen_name field(which represents the X username) is present.